### PR TITLE
1.3 -> 1.4

### DIFF
--- a/io.github.fastrizwaan.WineCharm.yaml
+++ b/io.github.fastrizwaan.WineCharm.yaml
@@ -201,8 +201,8 @@ modules:
       - gtk-update-icon-cache -f  /app/share/icons/hicolor
     sources:
       - type: git
-        tag: 1.3
-        commit: c9f43929546904d33a0be8ce564a0213ec8a74f7
+        tag: 1.4
+        commit: f5a9228cf3480e879c437fc07cfe04b5b312b389
         url: https://github.com/fastrizwaan/WineCharm.git
 
 


### PR DESCRIPTION
allow duplicate prefixes' exe shortcuts (2 exe files from different prefixes with same sha256sum)